### PR TITLE
Update nested switch instrumentation

### DIFF
--- a/clang/include/clang/AST/StatInfInstrStmtPrinter.h
+++ b/clang/include/clang/AST/StatInfInstrStmtPrinter.h
@@ -79,13 +79,14 @@ namespace clang {
     bool enter_then_body = false; // next CompoundStmt is the body of a then
     bool enter_else_body = false; // next CompoundStmt is the body of a else
     bool enter_main_function = false; // next CompoundStmt is the body of the main function
-    uint32_t switch_case_count = 0; // counts how much case a SwitchStmt has
     bool EnableStructuralAnalysis = true; // Enable the addition of the macros only for the structural analysis
     bool EnableTemporalAnalysis = true; // Enable the addition of the macros only for the temporal analysis
     bool entry_point_func = false; // next CompoundStmt is the configured entrypoint
     bool ret_entry_point_func = false; // keep the state of the entrypoint for return instruction
 
     std::stack<std::string> nested_switch_SID;
+    std::stack<std::uint32_t> nested_switch_num_cases;
+    std::stack<std::uint32_t> nested_switch_case_count;
 
   public:
     StatInfInstrStmtPrinter(raw_ostream &os, StatInfInstrDeclPrinter *dp, PrinterHelper *helper,

--- a/clang/lib/AST/StatInfInstrStmtPrinter.cpp
+++ b/clang/lib/AST/StatInfInstrStmtPrinter.cpp
@@ -316,7 +316,7 @@ void StatInfInstrStmtPrinter::VisitCaseStmt(CaseStmt *Node) {
   OS << ":" << NL;
 
   if(EnableStructuralAnalysis && enable_instrumentation)
-    Indent(Policy.Indentation) << "STATINF_SWITCH_CASE(" << nested_switch_SID.top() <<", " << switch_case_count++ << ");" << NL;
+    Indent(Policy.Indentation) << "STATINF_SWITCH_CASE(" << nested_switch_SID.top() <<", " << nested_switch_case_count.top()++ <<", " << nested_switch_num_cases.top() << ");" << NL;
 
   PrintStmt(Node->getSubStmt(), 0);
 }
@@ -324,7 +324,7 @@ void StatInfInstrStmtPrinter::VisitCaseStmt(CaseStmt *Node) {
 void StatInfInstrStmtPrinter::VisitDefaultStmt(DefaultStmt *Node) {
   Indent(-1) << "default:" << NL;
   if(EnableStructuralAnalysis && enable_instrumentation)
-    Indent(Policy.Indentation) << "STATINF_SWITCH_CASE(" << nested_switch_SID.top() <<", " << switch_case_count++ << ");" << NL;
+    Indent(Policy.Indentation) << "STATINF_SWITCH_CASE(" << nested_switch_SID.top() <<", " << nested_switch_case_count.top()++ <<", " << nested_switch_num_cases.top() << ");" << NL;
   PrintStmt(Node->getSubStmt(), 0);
 }
 
@@ -462,8 +462,9 @@ void StatInfInstrStmtPrinter::VisitSwitchStmt(SwitchStmt *Node) {
 
     std::string sid = "S"+std::to_string(Context->getSourceManager().getPresumedLoc(Node->getBeginLoc()).getLine());
     nested_switch_SID.push(sid);
+    nested_switch_num_cases.push(num_cases)
 
-    Indent() << "STATINF_INIT_SWITCH(" << nested_switch_SID.top() <<", " << num_cases << ");" << NL;
+    Indent() << "STATINF_INIT_SWITCH(" << nested_switch_SID.top() <<", " << nested_switch_num_cases.top() << ");" << NL;
   }
 
   Indent() << "switch (";
@@ -474,12 +475,13 @@ void StatInfInstrStmtPrinter::VisitSwitchStmt(SwitchStmt *Node) {
   else
     PrintExpr(Node->getCond());
   OS << ")";
-  switch_case_count = 0;
+  nested_switch_case_count.push(0);
   PrintControlledStmt(Node->getBody());
 
   if(EnableStructuralAnalysis && enable_instrumentation) {
-    Indent() << "STATINF_AFTER_SWITCH(" << nested_switch_SID.top() <<", "  << num_cases << ");" << NL;
+    Indent() << "STATINF_AFTER_SWITCH(" << nested_switch_SID.top() <<", "  << nested_switch_num_cases.top() << ");" << NL;
     nested_switch_SID.pop();
+    nested_switch_num_cases.pop();
   }
 }
 


### PR DESCRIPTION
We add a new argument to the macro `STATINF_SWITCH_CASE` because we need also the total number of cases in the switch instruction (i.e. `STATINF_SWITCH_CASE(SID, CID, NUM_CASES)`).
Probably, the `switch_case_count` variable used in `StatInfInstrStmtPrinter.c` should be a stack instead of a single uint32_t to support nested switch. Please check and verify if there other fix to be done and add corresponding commit before validating this PR